### PR TITLE
feat: Migrate Auto-Accept to CDP WebSocket bypass (port 9000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,32 @@ English | [中文文档](docs/README_zh.md)
 - **Code Context**: Manage code analysis caches per project
 - **Smart Cleanup**: Automatically closes related editor tabs
 
-### 🤖 Auto-Accept (Hands-free Mode)
+### 🤖 Auto-Accept (CDP Hands-free Mode)
 
-**Streamline your workflow**
-- Automatically accepts Agent-suggested terminal commands and file edits
-- Toggle on/off via the sidebar "Rocket" switch or command
-- Ideal for rapid prototyping when you trust the Agent's output
+**Streamline your workflow with Chromium DevTools Protocol bypass**
+- Automatically accepts Agent-suggested terminal commands and file edits.
+- Bypasses recent Antigravity Webview sandboxing by injecting clicks via the debug port.
+- Toggle on/off via the sidebar "Rocket" switch.
+
+> [!IMPORTANT]
+> **Setup Required:** For this feature to work, Antigravity must be launched with the `--remote-debugging-port=9000` flag. Lingering background processes will block this port.
+
+**Recommended Setup (Dedicated Launcher):**
+Create a script to cleanly kill background instances before launching.
+
+**Windows (Save as `Launch_Antigravity.bat`):**
+```bat
+@echo off
+taskkill /F /IM Antigravity.exe /T 2>nul
+start "" "D:\Develop\Antigravity\Antigravity.exe" --remote-debugging-port=9000
+```
+
+**macOS/Linux (Save as `launch_antigravity.sh`):**
+```bash
+#!/bin/bash
+pkill -f "Antigravity"
+/Applications/Antigravity.app/Contents/MacOS/Electron --remote-debugging-port=9000 &
+```
 
 ### ✨ Commit Message Generator (Claude)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,24 @@
 {
   "name": "antigravity-panel",
-  "version": "2.5.9",
+  "version": "2.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "antigravity-panel",
-      "version": "2.5.9",
+      "version": "2.5.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.44",
-        "lit": "^3.3.2"
+        "lit": "^3.3.2",
+        "ws": "^8.17.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.10.1",
         "@types/sinon": "^21.0.0",
         "@types/vscode": "^1.104.0",
+        "@types/ws": "^8.5.10",
         "@typescript-eslint/eslint-plugin": "^8.50.1",
         "@typescript-eslint/parser": "^8.50.1",
         "@vscode/vsce": "^3.7.1",
@@ -1535,6 +1537,16 @@
       "integrity": "sha512-0KwoU2rZ2ecsTGFxo4K1+f+AErRsYW0fsp6A0zufzGuhyczc2IoKqYqcwXidKXmy2u8YB2GsYsOtiI9Izx3Tig==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.50.1",
@@ -6945,6 +6957,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -426,6 +426,7 @@
     "@types/node": "^24.10.1",
     "@types/sinon": "^21.0.0",
     "@types/vscode": "^1.104.0",
+    "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^8.50.1",
     "@typescript-eslint/parser": "^8.50.1",
     "@vscode/vsce": "^3.7.1",
@@ -442,7 +443,8 @@
   },
   "dependencies": {
     "@vscode/codicons": "^0.0.44",
-    "lit": "^3.3.2"
+    "lit": "^3.3.2",
+    "ws": "^8.17.0"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/src/model/services/automation.service.ts
+++ b/src/model/services/automation.service.ts
@@ -1,44 +1,190 @@
 import * as vscode from 'vscode';
 import { IAutomationService } from './interfaces';
 import { Scheduler } from '../../shared/utils/scheduler';
-import { infoLog } from '../../shared/utils/logger';
+import { infoLog, errorLog } from '../../shared/utils/logger';
+import * as http from 'http';
+import WebSocket from 'ws';
 
 /**
- * AutomationService: Implements the hands-free auto-accept feature
+ * AutomationService: Implements the CDP (Chrome DevTools Protocol) auto-accept feature
+ * Bypasses UI sandboxing by connecting directly to the Chromium debugger.
  */
 export class AutomationService implements IAutomationService, vscode.Disposable {
     private scheduler: Scheduler;
     private readonly taskName = 'autoAccept';
     private _enabled = false;
 
+    // CDP State
+    private msgId = 1;
+    private connections = new Map<string, WebSocket>();
+    private readonly BASE_PORT = 9000;
+    private readonly PORT_RANGE = 5;
+
     constructor() {
         this.scheduler = new Scheduler({
-            onError: (_name, _err) => {
-                // Silently ignore command failures as they often fail when no step is pending
+            onError: (_name, err) => {
+                errorLog(`Automation error: ${err}`);
             }
         });
 
         this.scheduler.register({
             name: this.taskName,
-            interval: 800, // Slightly slower than 500ms to be less aggressive but still responsive
+            interval: 800, // Safe default interval
             execute: async () => {
                 if (!this._enabled) return;
-
-                // Try to accept agent steps and terminal commands
-                try {
-                    // These commands are registered by the Antigravity core extension
-                    await vscode.commands.executeCommand('antigravity.agent.acceptAgentStep');
-                } catch {
-                    // Ignore expected failures
-                }
-
-                try {
-                    await vscode.commands.executeCommand('antigravity.terminal.accept');
-                } catch {
-                    // Ignore expected failures
-                }
+                await this.performCdpAutoAccept();
             },
             immediate: false
+        });
+    }
+
+    /**
+     * Finds active webviews and evaluates the clicker script to bypass UI blocks
+     */
+    private async performCdpAutoAccept() {
+        for (let port = this.BASE_PORT - this.PORT_RANGE; port <= this.BASE_PORT + this.PORT_RANGE; port++) {
+            const pages = await this.getPages(port);
+            for (const page of pages) {
+                if (page.type !== 'page' && page.type !== 'webview') continue;
+                if ((page.title || "").includes("Extension Host")) continue;
+
+                const id = `${port}:${page.id}`;
+                if (!this.connections.has(id)) {
+                    if (page.webSocketDebuggerUrl) {
+                        await this.connectToPage(id, page.webSocketDebuggerUrl);
+                    }
+                }
+
+                const ws = this.connections.get(id);
+                if (ws && ws.readyState === WebSocket.OPEN as number) {
+                    await this.evaluate(ws, this.getClickerScript());
+                }
+            }
+        }
+    }
+
+    /**
+     * Native JS payload dropped straight into the webview execution context
+     */
+    private getClickerScript(): string {
+        return `
+            (() => {
+                const getAllRoots = (root = document) => {
+                    let roots = [root];
+                    try {
+                        const iframes = root.querySelectorAll('iframe, frame');
+                        for (const iframe of iframes) {
+                            try {
+                                const doc = iframe.contentDocument || iframe.contentWindow?.document;
+                                if (doc) roots.push(...getAllRoots(doc));
+                            } catch (e) { }
+                        }
+                        const shadowHosts = root.querySelectorAll('*');
+                        for (const el of shadowHosts) {
+                            if (el.shadowRoot) roots.push(...getAllRoots(el.shadowRoot));
+                        }
+                    } catch (e) { }
+                    return roots;
+                };
+
+                const roots = getAllRoots();
+                const pageTitle = document.title || "";
+                const isReviewPage = pageTitle.includes("Review Changes");
+
+                roots.forEach(root => {
+                    const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, null, false);
+                    let el;
+                    while (el = walker.nextNode()) {
+                        if (el.tagName === 'SCRIPT' || el.tagName === 'STYLE') continue;
+
+                        const rawText = (el.innerText || el.textContent || "").trim().toLowerCase();
+                        if (!rawText) continue;
+
+                        let isMatch = false;
+                        let isExpander = false;
+
+                        // Identify target tokens (Auto Accept logic, Permissions, etc.)
+                        if (['accept all', 'accept', 'confirm', 'run', 'always allow', 'allow once', 'allow'].includes(rawText)) isMatch = true;
+                        if (rawText.includes('always run') && rawText.length < 25) isMatch = true;
+                        if (rawText.startsWith('run alt')) isMatch = true;
+                        
+                        // Dropdowns/Expanders requiring revelation before clicking
+                        if (rawText.includes('requires input') || rawText === 'expand') { isMatch = true; isExpander = true; }
+                        if (rawText.includes('.js') || rawText.includes('.ts')) isMatch = false; // Noise filtering
+
+                        if (isMatch) {
+                            if (el.dataset.cdpSniperClicked === 'true') continue;
+
+                            // Security constraints for chat panel clicking
+                            if (!isReviewPage && !isExpander) {
+                                let safe = false;
+                                if (el.tagName === 'BUTTON') safe = true;
+                                try {
+                                    const style = window.getComputedStyle(el);
+                                    if (style.cursor === 'pointer') safe = true;
+                                } catch(e) {}
+                                if (!safe) continue;
+                                if (el.closest('pre') || el.closest('code')) continue;
+                            }
+
+                            // Mark as clicked
+                            el.dataset.cdpSniperClicked = 'true';
+                            if (isExpander) { setTimeout(() => { el.dataset.cdpSniperClicked = 'false'; }, 2000); }
+
+                            try {
+                                el.click(); 
+                                const rect = el.getBoundingClientRect();
+                                const opts = { view: window, bubbles: true, cancelable: true, clientX: rect.left + rect.width / 2, clientY: rect.top + rect.height / 2, buttons: 1 };
+                                el.dispatchEvent(new MouseEvent('mousedown', opts));
+                                el.dispatchEvent(new MouseEvent('mouseup', opts));
+                                el.dispatchEvent(new MouseEvent('click', opts));
+                            } catch(e) {}
+
+                            // Robust parent triggering for React synthetic events
+                            let p = el.parentElement;
+                            if (p) { p.click(); if (p.parentElement) p.parentElement.click(); }
+                        }
+                    }
+                });
+            })()
+        `;
+    }
+
+    private async getPages(port: number): Promise<any[]> {
+        return new Promise((resolve) => {
+            const req = http.get({ hostname: '127.0.0.1', port, path: '/json/list', timeout: 500 }, (res) => {
+                let body = '';
+                res.on('data', chunk => body += chunk);
+                res.on('end', () => {
+                    try { resolve(JSON.parse(body)); } catch { resolve([]); }
+                });
+            });
+            req.on('error', () => resolve([]));
+            req.on('timeout', () => { req.destroy(); resolve([]); });
+        });
+    }
+
+    private async connectToPage(id: string, wsUrl: string): Promise<boolean> {
+        return new Promise((resolve) => {
+            const ws = new WebSocket(wsUrl);
+            ws.on('open', () => {
+                this.connections.set(id, ws);
+                ws.send(JSON.stringify({ id: this.msgId++, method: 'Runtime.enable' }));
+                resolve(true);
+            });
+            ws.on('error', () => resolve(false));
+            ws.on('close', () => this.connections.delete(id));
+        });
+    }
+
+    private async evaluate(ws: WebSocket, expression: string): Promise<void> {
+        return new Promise((resolve) => {
+            ws.send(JSON.stringify({
+                id: this.msgId++,
+                method: 'Runtime.evaluate',
+                params: { expression, userGesture: true, awaitPromise: true }
+            }));
+            resolve();
         });
     }
 
@@ -46,14 +192,14 @@ export class AutomationService implements IAutomationService, vscode.Disposable 
         if (this._enabled) return;
         this._enabled = true;
         this.scheduler.start(this.taskName);
-        infoLog("Automation: Auto-accept enabled");
+        infoLog("Automation: Auto-accept connected via Chrome DevTools Protocol");
     }
 
     stop(): void {
         if (!this._enabled) return;
         this._enabled = false;
         this.scheduler.stop(this.taskName);
-        infoLog("Automation: Auto-accept disabled");
+        infoLog("Automation: Auto-accept disconnected");
     }
 
     isRunning(): boolean {
@@ -75,5 +221,9 @@ export class AutomationService implements IAutomationService, vscode.Disposable 
 
     dispose(): void {
         this.scheduler.dispose();
+        this.connections.forEach(ws => {
+            try { ws.close(); } catch { /* ignore */ }
+        });
+        this.connections.clear();
     }
 }


### PR DESCRIPTION
The existing antigravity.agent.acceptAgentStep command has been deprecated and UI sandboxing prevents DOM injection. This PR completely rewrites the Auto-Accept logic to use the Chromium DevTools Protocol (CDP) via WebSocket (port 9000), allowing reliable background bypassing. I also updated the README.md with instructions on how users should relaunch the IDE to cleanly expose the debug port.