### PR TITLE
fix: Antigravity Toolkit sidebar title; Gemini Flash vs Pro quota grouping

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -66,7 +66,7 @@
     "extension.description": "The essential toolkit for Google Antigravity IDE users. Monitor quotas, manage caches, and visualize system metrics.",
     "extension.displayName": "Toolkit for Antigravity",
     "views.tfa.sidebar.name": "Antigravity: Toolkit",
-    "viewsContainers.tfa-sidebar.title": "Antigravity",
+    "viewsContainers.tfa-sidebar.title": "Antigravity Toolkit",
     "quota.notification.warning": "Low Quota Warning: {0} quota is below {1}% ({2}% remaining).",
     "quota.notification.critical": "CRITICAL Quota: {0} quota is below {1}% ({2}% remaining). Use with caution!"
 }

--- a/src/model/strategy.ts
+++ b/src/model/strategy.ts
@@ -1,6 +1,6 @@
 /**
  * Quota Strategy Manager
- * 
+ *
  * Logic for grouping models and determining display properties based on configuration.
  */
 
@@ -50,20 +50,37 @@ export class QuotaStrategyManager {
       }
     }
 
-    // 2. Configuration Driven Prefix/Keyword Matching
+    // 2. Configuration Driven Prefix/Keyword Matching (longest prefix wins)
     const lowerId = modelId.toLowerCase();
     const lowerLabel = modelLabel?.toLowerCase() || '';
 
+    type PrefixMatch = { group: GroupDefinition; prefixLen: number };
+    const matches: PrefixMatch[] = [];
+
     for (const group of this.groups) {
-      if (group.prefixes) {
-        for (const prefix of group.prefixes) {
-          const p = prefix.toLowerCase();
-          // Priority 1: ID contains prefix
-          if (lowerId.includes(p)) return group;
-          // Priority 2: Label contains prefix (Fallback)
-          if (modelLabel && lowerLabel.includes(p)) return group;
+      if (!group.prefixes) continue;
+      for (const prefix of group.prefixes) {
+        const p = prefix.toLowerCase();
+        // The broad "gemini" prefix must not classify Gemini Flash (IDs and labels like "Gemini 3 Flash").
+        if (group.id === 'gemini-pro' && p === 'gemini') {
+          if (lowerId.includes('flash') || lowerLabel.includes('flash')) {
+            continue;
+          }
+        }
+        const inId = lowerId.includes(p);
+        const inLabel = modelLabel !== undefined && lowerLabel.includes(p);
+        if (inId || inLabel) {
+          matches.push({ group, prefixLen: p.length });
         }
       }
+    }
+
+    if (matches.length > 0) {
+      matches.sort((a, b) => {
+        if (b.prefixLen !== a.prefixLen) return b.prefixLen - a.prefixLen;
+        return this.groups.indexOf(a.group) - this.groups.indexOf(b.group);
+      });
+      return matches[0].group;
     }
 
     // 3. Classify as "Other"

--- a/src/shared/config/quota_strategy.json
+++ b/src/shared/config/quota_strategy.json
@@ -6,7 +6,8 @@
             "shortLabel": "Flash",
             "themeColor": "#40C4FF",
             "prefixes": [
-                "gemini-3-flash"
+                "gemini-3-flash",
+                "flash"
             ],
             "models": [
                 {

--- a/src/test/suite/quota_strategy_manager.test.ts
+++ b/src/test/suite/quota_strategy_manager.test.ts
@@ -57,6 +57,14 @@ suite('QuotaStrategyManager Test Suite', () => {
         assert.strictEqual(group.id, 'gemini-pro');
     });
 
+    test('should classify Gemini Flash labels without mixing into Pro', () => {
+        const byHumanLabel = manager.getGroupForModel('opaque-internal-id', 'Gemini 3 Flash');
+        assert.strictEqual(byHumanLabel.id, 'gemini-flash');
+
+        const byId = manager.getGroupForModel('vendor-model-gemini-3-flash-preview');
+        assert.strictEqual(byId.id, 'gemini-flash');
+    });
+
     test('should return first group for unknown models', () => {
         const group = manager.getGroupForModel('completely-unknown-model');
         assert.ok(group, 'Should return a fallback group');


### PR DESCRIPTION
## Summary

- **Activity bar title**: `viewsContainers.tfa-sidebar.title` now reads **Antigravity Toolkit** (was **Antigravity**), matching the product name users expect.
- **Gemini Flash vs Pro**: The broad Pro prefix `gemini` matched any label containing “Gemini”, so **Gemini 3 Flash** (and similar) was grouped under **Gemini Pro**. Group aggregation then picks the **minimum** remaining percentage among models in that group, which looked like Flash and Pro were merged or like min(Flash, Pro).

## Changes

- **Prefix matching**: Collect all prefix hits, choose the **longest** match, and **skip** the generic `gemini` Pro rule when the model id or label contains **flash** (so Flash never steals into Pro).
- **Config**: Added **`flash`** to the Gemini Flash prefix list to improve label-only matches.

Fixes n2ns/antigravity-panel#120 and aligns with #121 (Flash visibility) where mis-grouping was a factor.
