### PR TITLE
fix(quota): align reset window and labels with API cycles

### DIFF
--- a/src/model/services/quota.service.ts
+++ b/src/model/services/quota.service.ts
@@ -272,6 +272,20 @@ export class QuotaService implements IQuotaService {
         if (hours >= 24) {
             const days = Math.floor(hours / 24);
             const remainingHours = hours % 24;
+            if (days >= 7) {
+                const weeks = Math.floor(days / 7);
+                const remDays = days % 7;
+                if (remDays === 0 && remainingHours === 0) {
+                    return `${weeks}w`;
+                }
+                if (remDays === 0) {
+                    return `${weeks}w ${remainingHours}h`;
+                }
+                if (remainingHours === 0) {
+                    return `${weeks}w ${remDays}d`;
+                }
+                return `${weeks}w ${remDays}d ${remainingHours}h`;
+            }
             return `${days}d ${remainingHours}h`;
         }
         return `${hours}h ${mins % 60}m`;

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -5,10 +5,11 @@
 // ==================== Quota Related ====================
 
 /**
- * Google quota reset interval (hours)
- * All Google AI model quotas reset every 5 hours
+ * Fallback window (hours) for sidebar chart runway math only when the server does not
+ * provide a usable per-model reset time. Real cycles are defined by the API (rolling hours,
+ * multi-day, weekly, etc.).
  */
-export const QUOTA_RESET_HOURS = 5;
+export const QUOTA_RESET_HOURS_FALLBACK = 24;
 
 // ==================== Path Related ====================
 

--- a/src/view-model/app.vm.ts
+++ b/src/view-model/app.vm.ts
@@ -9,7 +9,7 @@ import type { TfaConfig } from '../shared/utils/types';
 import type { QuotaStrategyManager } from '../model/strategy';
 import type { ConfigManager } from '../shared/config/config_manager';
 import { formatBytes } from '../shared/utils/format';
-import { QUOTA_RESET_HOURS } from '../shared/utils/constants';
+import { QUOTA_RESET_HOURS_FALLBACK } from '../shared/utils/constants';
 import type {
     AppState,
     QuotaViewState,
@@ -535,6 +535,24 @@ export class AppViewModel implements vscode.Disposable {
         });
     }
 
+    /**
+     * Hours until the next quota reset for the active group, from API `resetTime` on the
+     * lowest-remaining model (same rule as aggregateGroups). Used for prediction instead of a fixed 5h window.
+     */
+    private getHoursUntilResetForGroup(groupId: string): number | null {
+        if (!this._lastSnapshot?.models?.length) return null;
+        const groupModels = this._lastSnapshot.models.filter(m =>
+            this.strategyManager.getGroupForModel(m.modelId, m.label).id === groupId
+        );
+        if (groupModels.length === 0) return null;
+        const minModel = groupModels.reduce((min, m) =>
+            m.remainingPercentage < min.remainingPercentage ? m : min
+        );
+        const ms = minModel.resetTime.getTime() - Date.now();
+        if (ms <= 0) return null;
+        return ms / 3_600_000;
+    }
+
     private detectActiveGroup(prevState: QuotaViewState, newGroups: QuotaGroupState[]): string {
         const config = this.configManager.getConfig();
         const hiddenGroupId = config["dashboard.includeSecondaryModels"] ? null : 'gpt';
@@ -605,6 +623,26 @@ export class AppViewModel implements vscode.Disposable {
         return max || 1;
     }
 
+    /** Human-readable runway for the usage chart when burn rate would exhaust quota before reset. */
+    private formatRunwayDuration(hours: number): string {
+        if (hours < 1) {
+            return `~${Math.round(hours * 60)}m`;
+        }
+        if (hours < 24) {
+            return `~${Math.round(hours)}h`;
+        }
+        const days = hours / 24;
+        if (days < 7) {
+            return `~${Math.round(days)}d`;
+        }
+        const weeks = Math.floor(days / 7);
+        const remDays = Math.round(days - weeks * 7);
+        if (remDays <= 0) {
+            return `~${weeks}w`;
+        }
+        return `~${weeks}w ${remDays}d`;
+    }
+
     private calculatePrediction(
         buckets: UsageBucket[],
         activeGroupId: string,
@@ -621,10 +659,12 @@ export class AppViewModel implements vscode.Disposable {
         const usageRate = (historyDisplayMinutes / 60) > 0 ? totalUsage / (historyDisplayMinutes / 60) : 0;
         let runway = 'Stable';
         if (usageRate > 0 && currentRemaining > 0) {
-            const estimatedUsageBeforeReset = usageRate * QUOTA_RESET_HOURS;
+            const hoursUntilReset =
+                this.getHoursUntilResetForGroup(activeGroupId) ?? QUOTA_RESET_HOURS_FALLBACK;
+            const estimatedUsageBeforeReset = usageRate * hoursUntilReset;
             if (estimatedUsageBeforeReset >= currentRemaining) {
                 const hoursUntilEmpty = currentRemaining / usageRate;
-                runway = hoursUntilEmpty >= 1 ? `~${Math.round(hoursUntilEmpty)}h` : `~${Math.round(hoursUntilEmpty * 60)}m`;
+                runway = this.formatRunwayDuration(hoursUntilEmpty);
             }
         }
         const activeGroup = this.strategyManager.getGroups().find(g => g.id === activeGroupId);


### PR DESCRIPTION
## Summary

- Removes the old **5-hour** assumption used for sidebar chart runway prediction. The chart now uses **hours until reset** from each model’s API `resetTime` (same min-remaining rule as group aggregation), with a **24h fallback** only when the server does not provide a usable time.
- Extends **status bar** time strings for long cycles (for example, weeks and days).
- Formats chart **runway** in days or weeks when exhaustion would take a long time.

## Related

- Companion PR for **Claude + GPT shared pool**: [#129](https://github.com/n2ns/antigravity-panel/pull/129) (branch `fix/claude-gpt-shared-pool` on the fork). Merge **#128** before **#129**.
