### PR TITLE
fix(quota): aggregate Claude+GPT as one shared pool

### DIFF
--- a/src/model/services/quota.service.ts
+++ b/src/model/services/quota.service.ts
@@ -272,6 +272,20 @@ export class QuotaService implements IQuotaService {
         if (hours >= 24) {
             const days = Math.floor(hours / 24);
             const remainingHours = hours % 24;
+            if (days >= 7) {
+                const weeks = Math.floor(days / 7);
+                const remDays = days % 7;
+                if (remDays === 0 && remainingHours === 0) {
+                    return `${weeks}w`;
+                }
+                if (remDays === 0) {
+                    return `${weeks}w ${remainingHours}h`;
+                }
+                if (remainingHours === 0) {
+                    return `${weeks}w ${remDays}d`;
+                }
+                return `${weeks}w ${remDays}d ${remainingHours}h`;
+            }
             return `${days}d ${remainingHours}h`;
         }
         return `${hours}h ${mins % 60}m`;

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -11,6 +11,12 @@
  */
 export const QUOTA_RESET_HOURS_FALLBACK = 24;
 
+/**
+ * Quota groups that share one backend pool in Antigravity (Anthropic + OpenAI OSS rows).
+ * Aggregated remaining % and reset time use the minimum across all models in this pool.
+ */
+export const SHARED_QUOTA_POOL_GROUP_IDS = ['claude', 'gpt'] as const;
+
 // ==================== Path Related ====================
 
 /** Gemini root directory name (relative to user home) */

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -5,10 +5,11 @@
 // ==================== Quota Related ====================
 
 /**
- * Google quota reset interval (hours)
- * All Google AI model quotas reset every 5 hours
+ * Fallback window (hours) for sidebar chart runway math only when the server does not
+ * provide a usable per-model reset time. Real cycles are defined by the API (rolling hours,
+ * multi-day, weekly, etc.).
  */
-export const QUOTA_RESET_HOURS = 5;
+export const QUOTA_RESET_HOURS_FALLBACK = 24;
 
 // ==================== Path Related ====================
 

--- a/src/test/suite/app.vm.test.ts
+++ b/src/test/suite/app.vm.test.ts
@@ -109,12 +109,12 @@ suite('AppViewModel Test Suite', () => {
     });
 
     test('refreshQuota should update state from service', async () => {
-        // Setup mock return
+        // Use Gemini Flash (not Claude/GPT shared pool) so exactly one group has quota data.
         const snapshot: QuotaSnapshot = {
             timestamp: new Date(),
             models: [{
-                modelId: 'gpt-4',
-                label: 'GPT-4',
+                modelId: 'MODEL_PLACEHOLDER_M18',
+                label: 'Gemini 3 Flash',
                 remainingPercentage: 50,
                 isExhausted: false,
                 resetTime: new Date(),
@@ -126,13 +126,9 @@ suite('AppViewModel Test Suite', () => {
         await vm.refreshQuota();
 
         const state = vm.getState();
-        // Assuming strategy config maps 'gpt-4' to a group (likely 'gpt' or 'gemini' depending on default internal config, 
-        // strictly speaking strategy.json defines this. Assuming 'gpt' group exists or default group)
-
-        // Note: strategy.ts imports local json. If that json has id="gpt", we check that.
-        // Let's check for ANY group having hasData=true
         const activeGroups = state.quota.groups.filter(g => g.hasData);
         assert.strictEqual(activeGroups.length, 1, 'Should have 1 active group');
+        assert.strictEqual(activeGroups[0].id, 'gemini-flash');
         assert.strictEqual(activeGroups[0].remaining, 50);
     });
 
@@ -183,6 +179,40 @@ suite('AppViewModel Test Suite', () => {
         if (claudeGroup) {
             assert.strictEqual(state.quota.activeGroupId, claudeGroup.id);
         }
+    });
+
+    test('Claude and GPT shared pool: both groups mirror min remaining and reset from combined models', async () => {
+        const gptReset = new Date(Date.now() + 48 * 3600000);
+        mockQuota.fetchQuota = async () => ({
+            timestamp: new Date(),
+            models: [
+                {
+                    modelId: 'MODEL_CLAUDE_4_5_SONNET',
+                    label: 'Claude Sonnet 4.5',
+                    remainingPercentage: 70,
+                    isExhausted: false,
+                    resetTime: new Date(Date.now() + 5 * 3600000),
+                    timeUntilReset: '5h'
+                },
+                {
+                    modelId: 'MODEL_OPENAI_GPT_OSS_120B_MEDIUM',
+                    label: 'GPT-OSS 120B (Medium)',
+                    remainingPercentage: 45,
+                    isExhausted: false,
+                    resetTime: gptReset,
+                    timeUntilReset: '2d'
+                }
+            ]
+        });
+        await vm.refreshQuota();
+        const state = vm.getState();
+        const claudeG = state.quota.groups.find(g => g.id === 'claude');
+        const gptG = state.quota.groups.find(g => g.id === 'gpt');
+        assert.ok(claudeG?.hasData && gptG?.hasData, 'both pool groups should have data');
+        assert.strictEqual(claudeG!.remaining, 45, 'Claude row should use pool minimum');
+        assert.strictEqual(gptG!.remaining, 45);
+        assert.strictEqual(claudeG!.resetTime, gptG!.resetTime);
+        assert.strictEqual(claudeG!.resetTime, '2d');
     });
 
     test('deleteTask should call service and refresh', async () => {

--- a/src/view-model/app.vm.ts
+++ b/src/view-model/app.vm.ts
@@ -9,7 +9,7 @@ import type { TfaConfig } from '../shared/utils/types';
 import type { QuotaStrategyManager } from '../model/strategy';
 import type { ConfigManager } from '../shared/config/config_manager';
 import { formatBytes } from '../shared/utils/format';
-import { QUOTA_RESET_HOURS } from '../shared/utils/constants';
+import { QUOTA_RESET_HOURS_FALLBACK } from '../shared/utils/constants';
 import type {
     AppState,
     QuotaViewState,
@@ -535,6 +535,24 @@ export class AppViewModel implements vscode.Disposable {
         });
     }
 
+    /**
+     * Hours until the next quota reset for the active group, from API `resetTime` on the
+     * lowest-remaining model (same rule as aggregateGroups). Used for prediction instead of a fixed 5h window.
+     */
+    private getHoursUntilResetForGroup(groupId: string): number | null {
+        if (!this._lastSnapshot?.models?.length) return null;
+        const groupModels = this._lastSnapshot.models.filter(m =>
+            this.strategyManager.getGroupForModel(m.modelId, m.label).id === groupId
+        );
+        if (groupModels.length === 0) return null;
+        const minModel = groupModels.reduce((min, m) =>
+            m.remainingPercentage < min.remainingPercentage ? m : min
+        );
+        const ms = minModel.resetTime.getTime() - Date.now();
+        if (ms <= 0) return null;
+        return ms / 3_600_000;
+    }
+
     private detectActiveGroup(prevState: QuotaViewState, newGroups: QuotaGroupState[]): string {
         const config = this.configManager.getConfig();
         const hiddenGroupId = config["dashboard.includeSecondaryModels"] ? null : 'gpt';
@@ -605,6 +623,26 @@ export class AppViewModel implements vscode.Disposable {
         return max || 1;
     }
 
+    /** Human-readable runway for the usage chart when burn rate would exhaust quota before reset. */
+    private formatRunwayDuration(hours: number): string {
+        if (hours < 1) {
+            return `~${Math.round(hours * 60)}m`;
+        }
+        if (hours < 24) {
+            return `~${Math.round(hours)}h`;
+        }
+        const days = hours / 24;
+        if (days < 7) {
+            return `~${Math.round(days)}d`;
+        }
+        const weeks = Math.floor(days / 7);
+        const remDays = Math.round(days - weeks * 7);
+        if (remDays <= 0) {
+            return `~${weeks}w`;
+        }
+        return `~${weeks}w ${remDays}d`;
+    }
+
     private calculatePrediction(
         buckets: UsageBucket[],
         activeGroupId: string,
@@ -621,10 +659,12 @@ export class AppViewModel implements vscode.Disposable {
         const usageRate = (historyDisplayMinutes / 60) > 0 ? totalUsage / (historyDisplayMinutes / 60) : 0;
         let runway = 'Stable';
         if (usageRate > 0 && currentRemaining > 0) {
-            const estimatedUsageBeforeReset = usageRate * QUOTA_RESET_HOURS;
+            const hoursUntilReset =
+                this.getHoursUntilResetForGroup(activeGroupId) ?? QUOTA_RESET_HOURS_FALLBACK;
+            const estimatedUsageBeforeReset = usageRate * hoursUntilReset;
             if (estimatedUsageBeforeReset >= currentRemaining) {
                 const hoursUntilEmpty = currentRemaining / usageRate;
-                runway = hoursUntilEmpty >= 1 ? `~${Math.round(hoursUntilEmpty)}h` : `~${Math.round(hoursUntilEmpty * 60)}m`;
+                runway = this.formatRunwayDuration(hoursUntilEmpty);
             }
         }
         const activeGroup = this.strategyManager.getGroups().find(g => g.id === activeGroupId);

--- a/src/view-model/app.vm.ts
+++ b/src/view-model/app.vm.ts
@@ -4,12 +4,12 @@
 
 import * as vscode from 'vscode';
 import type { IQuotaService, ICacheService, IStorageService, IAutomationService } from '../model/services/interfaces';
-import type { QuotaSnapshot, BrainTask, CacheInfo, CodeContext, FileItem } from '../model/types/entities';
+import type { QuotaSnapshot, BrainTask, CacheInfo, CodeContext, FileItem, ModelQuotaInfo } from '../model/types/entities';
 import type { TfaConfig } from '../shared/utils/types';
 import type { QuotaStrategyManager } from '../model/strategy';
 import type { ConfigManager } from '../shared/config/config_manager';
 import { formatBytes } from '../shared/utils/format';
-import { QUOTA_RESET_HOURS_FALLBACK } from '../shared/utils/constants';
+import { QUOTA_RESET_HOURS_FALLBACK, SHARED_QUOTA_POOL_GROUP_IDS } from '../shared/utils/constants';
 import type {
     AppState,
     QuotaViewState,
@@ -40,6 +40,8 @@ export type {
 };
 
 const ACTIVE_GROUP_THRESHOLD = 0.1;
+
+const SHARED_POOL_ID_SET = new Set<string>(SHARED_QUOTA_POOL_GROUP_IDS);
 
 export class AppViewModel implements vscode.Disposable {
     private _state: AppState;
@@ -496,14 +498,20 @@ export class AppViewModel implements vscode.Disposable {
         return value.toString();
     }
 
-    private aggregateGroups(snapshot: QuotaSnapshot): QuotaGroupState[] {
+    /** Claude + GPT share one pool; aggregate using all models in that pool, not per-row in isolation. */
+    private getModelsForGroupFromSnapshot(snapshot: QuotaSnapshot, groupId: string): ModelQuotaInfo[] {
         const models = snapshot.models || [];
+        if (SHARED_POOL_ID_SET.has(groupId)) {
+            return models.filter(m => SHARED_POOL_ID_SET.has(this.strategyManager.getGroupForModel(m.modelId, m.label).id));
+        }
+        return models.filter(m => this.strategyManager.getGroupForModel(m.modelId, m.label).id === groupId);
+    }
+
+    private aggregateGroups(snapshot: QuotaSnapshot): QuotaGroupState[] {
         const groups = this.strategyManager.getGroups();
 
         return groups.map(group => {
-            const groupModels = models.filter(m =>
-                this.strategyManager.getGroupForModel(m.modelId, m.label).id === group.id
-            );
+            const groupModels = this.getModelsForGroupFromSnapshot(snapshot, group.id);
 
             if (groupModels.length === 0) {
                 return {
@@ -537,13 +545,12 @@ export class AppViewModel implements vscode.Disposable {
 
     /**
      * Hours until the next quota reset for the active group, from API `resetTime` on the
-     * lowest-remaining model (same rule as aggregateGroups). Used for prediction instead of a fixed 5h window.
+     * lowest-remaining model (same rule as aggregateGroups, including Claude+GPT shared pool).
+     * Used for prediction instead of a fixed window.
      */
     private getHoursUntilResetForGroup(groupId: string): number | null {
         if (!this._lastSnapshot?.models?.length) return null;
-        const groupModels = this._lastSnapshot.models.filter(m =>
-            this.strategyManager.getGroupForModel(m.modelId, m.label).id === groupId
-        );
+        const groupModels = this.getModelsForGroupFromSnapshot(this._lastSnapshot, groupId);
         if (groupModels.length === 0) return null;
         const minModel = groupModels.reduce((min, m) =>
             m.remainingPercentage < min.remainingPercentage ? m : min
@@ -777,9 +784,7 @@ export class AppViewModel implements vscode.Disposable {
                 // Find the original model info to get absolute date
                 let resetDate: Date | undefined;
                 if (this._lastSnapshot && this._lastSnapshot.models) {
-                    const groupModels = this._lastSnapshot.models.filter(m =>
-                        this.strategyManager.getGroupForModel(m.modelId, m.label).id === g.id
-                    );
+                    const groupModels = this.getModelsForGroupFromSnapshot(this._lastSnapshot, g.id);
                     if (groupModels.length > 0) {
                         // Use the earliest reset time (min model) similar to aggregateGroups logic
                         const minModel = groupModels.reduce((min, m) =>


### PR DESCRIPTION
## Summary

Antigravity documents that **GPT shares a quota pool with Claude**. The UI previously aggregated **Claude** and **GPT** using only each group’s own model rows, so the two lines could show different remaining percentage or reset timers for the same pool.

This change applies **one** aggregate for that pool: **minimum remaining percentage** and the **same** reset countdown for both groups, using all Claude and GPT models in the snapshot.

## Merge order

1. Merge **[#128](https://github.com/n2ns/antigravity-panel/pull/128)** first (quota reset API alignment).
2. After it is on `main`, merge this PR. It should add only the shared-pool commit on top.

## Single-commit review

Diff for the shared-pool change only (compare after **#128**’s commit):

https://github.com/AMDphreak/antigravity-panel/compare/fix/quota-reset-api...fix/claude-gpt-shared-pool

## Code changes

- `SHARED_QUOTA_POOL_GROUP_IDS` — `claude`, `gpt`
- `getModelsForGroupFromSnapshot` — shared pool uses the combined model set for aggregation, hours-until-reset, and status bar `resetDate`
- Unit test when Claude and GPT rows disagree; `refreshQuota` test uses Gemini Flash so a single model snapshot does not double-count the pool
