### PR TITLE
feat: display user tier available credits in status bar and sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "antigravity-panel",
-  "version": "2.5.12",
+  "version": "2.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "antigravity-panel",
-      "version": "2.5.12",
+      "version": "2.5.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.44",

--- a/src/model/services/quota.service.ts
+++ b/src/model/services/quota.service.ts
@@ -168,6 +168,7 @@ export class QuotaService implements IQuotaService {
         const planInfo = userStatus.planStatus?.planInfo;
         const availableCredits = userStatus.planStatus?.availablePromptCredits;
         const availableFlowCredits = userStatus.planStatus?.availableFlowCredits;
+        const userTier = userStatus.userTier;
 
         // Parse Prompt Credits
         let promptCredits: PromptCreditsInfo | undefined;
@@ -216,7 +217,6 @@ export class QuotaService implements IQuotaService {
         }
 
         // Extract user subscription info
-        const userTier = userStatus.userTier;
         const userInfo: UserInfo | undefined = userStatus.name || userTier ? {
             name: userStatus.name,
             email: userStatus.email,

--- a/src/model/services/quota.service.ts
+++ b/src/model/services/quota.service.ts
@@ -20,6 +20,7 @@ import type {
     ErrorCallback,
     LanguageServerInfo,
     UserInfo,
+    UserCredit,
 } from '../types/entities';
 
 // Re-export types for backward compatibility
@@ -200,7 +201,8 @@ export class QuotaService implements IQuotaService {
 
         // Build combined token usage info
         let tokenUsage: TokenUsageInfo | undefined;
-        if (promptCredits || flowCredits) {
+        const credits = userTier?.availableCredits || [];
+        if (promptCredits || flowCredits || credits.length > 0) {
             const totalAvailable = (promptCredits?.available || 0) + (flowCredits?.available || 0);
             const totalMonthly = (promptCredits?.monthly || 0) + (flowCredits?.monthly || 0);
             tokenUsage = {
@@ -209,6 +211,7 @@ export class QuotaService implements IQuotaService {
                 totalAvailable,
                 totalMonthly,
                 overallRemainingPercentage: totalMonthly > 0 ? (totalAvailable / totalMonthly) * 100 : 0,
+                userCredits: credits,
             };
         }
 
@@ -312,6 +315,7 @@ interface ServerUserStatusResponse {
             description?: string;
             upgradeSubscriptionUri?: string;
             upgradeSubscriptionText?: string;
+            availableCredits?: UserCredit[];
         };
         planStatus?: {
             planInfo: {

--- a/src/model/types/entities.ts
+++ b/src/model/types/entities.ts
@@ -17,6 +17,7 @@ export type {
     TokenUsageInfo,
     QuotaSnapshot,
     UserInfo,
+    UserCredit,
 
     // Process Detection Related
     LanguageServerInfo,

--- a/src/shared/utils/types.ts
+++ b/src/shared/utils/types.ts
@@ -51,6 +51,11 @@ export interface FlowCreditsInfo {
   remainingPercentage: number;
 }
 
+export interface UserCredit {
+  creditType: string;
+  creditAmount: string;
+}
+
 /**
  * Combined Token Usage information for display
  */
@@ -65,6 +70,8 @@ export interface TokenUsageInfo {
   totalMonthly: number;
   /** Overall remaining percentage */
   overallRemainingPercentage: number;
+  /** User tier credits (like GOOGLE_ONE_AI) */
+  userCredits?: UserCredit[];
 }
 
 /**

--- a/src/view-model/app.vm.ts
+++ b/src/view-model/app.vm.ts
@@ -412,6 +412,7 @@ export class AppViewModel implements vscode.Disposable {
                 totalAvailable: tu.totalAvailable,
                 totalMonthly: tu.totalMonthly,
                 overallRemainingPercentage: tu.overallRemainingPercentage,
+                userCredits: tu.userCredits,
                 formatted: {
                     promptAvailable: this.formatCredits(tu.promptCredits?.available),
                     promptMonthly: this.formatCredits(tu.promptCredits?.monthly),

--- a/src/view-model/types.ts
+++ b/src/view-model/types.ts
@@ -5,7 +5,7 @@
  * These types represent the UI-ready data structures.
  */
 
-import type { UsageBucket, BucketItem } from '../model/types/entities';
+import type { UsageBucket, BucketItem, UserCredit } from '../model/types/entities';
 
 // ==================== Quota View State ====================
 
@@ -169,6 +169,8 @@ export interface TokenUsageViewState {
     totalMonthly: number;
     /** Overall remaining percentage */
     overallRemainingPercentage: number;
+    /** User tier credits (like GOOGLE_ONE_AI) */
+    userCredits?: UserCredit[];
     /** Formatted display strings */
     formatted: {
         promptAvailable: string;

--- a/src/view/status-bar.ts
+++ b/src/view/status-bar.ts
@@ -129,6 +129,16 @@ export class StatusBarManager implements vscode.Disposable {
             tooltipRows.push(`| 💿 Cache | ${formatBytes(cache.totalSize)} |  | |`);
         }
 
+        const credits = this.viewModel.getState().tokenUsage?.userCredits || [];
+        credits.forEach(credit => {
+            parts.push(`💳 ${credit.creditAmount}`);
+            const label = credit.creditType
+                .split('_')
+                .map(w => w.toLowerCase() === 'ai' ? 'AI' : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+                .join(' ');
+            tooltipRows.push(`| 💳 ${label} | ${credit.creditAmount} |  | |`);
+        });
+
         if (parts.length === 0) {
             this.item.text = "$(check) TFA"; // Use check icon if nothing to show but bar is enabled, or just TFA
         } else {

--- a/src/view/status-bar.ts
+++ b/src/view/status-bar.ts
@@ -129,15 +129,17 @@ export class StatusBarManager implements vscode.Disposable {
             tooltipRows.push(`| 💿 Cache | ${formatBytes(cache.totalSize)} |  | |`);
         }
 
-        const credits = this.viewModel.getState().tokenUsage?.userCredits || [];
-        credits.forEach(credit => {
-            parts.push(`💳 ${credit.creditAmount}`);
-            const label = credit.creditType
-                .split('_')
-                .map(w => w.toLowerCase() === 'ai' ? 'AI' : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
-                .join(' ');
-            tooltipRows.push(`| 💳 ${label} | ${credit.creditAmount} |  | |`);
-        });
+        if (showQuota) {
+            const credits = this.viewModel.getState().tokenUsage?.userCredits || [];
+            credits.forEach(credit => {
+                parts.push(`💳 ${credit.creditAmount}`);
+                const label = credit.creditType
+                    .split('_')
+                    .map(w => w.toLowerCase() === 'ai' ? 'AI' : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+                    .join(' ');
+                tooltipRows.push(`| 💳 ${label} | ${credit.creditAmount} |  | |`);
+            });
+        }
 
         if (parts.length === 0) {
             this.item.text = "$(check) TFA"; // Use check icon if nothing to show but bar is enabled, or just TFA

--- a/src/view/webview/components/credits-bar.ts
+++ b/src/view/webview/components/credits-bar.ts
@@ -20,11 +20,11 @@ export class CreditsBar extends LitElement {
       return html``;
     }
 
-    const { promptCredits, flowCredits, formatted } = this.tokenUsage;
+    const { promptCredits, flowCredits, formatted, userCredits } = this.tokenUsage;
     const t = (window as unknown as WindowWithVsCode).__TRANSLATIONS__ || {};
 
     // If no data, don't render
-    if (!promptCredits && !flowCredits) {
+    if (!promptCredits && !flowCredits && (!userCredits || userCredits.length === 0)) {
       return html``;
     }
 
@@ -49,6 +49,18 @@ export class CreditsBar extends LitElement {
             </div>
           </div>
         ` : ''}
+        ${userCredits ? userCredits.map(c => {
+          const label = c.creditType.split('_').map(w => w.toLowerCase() === 'ai' ? 'AI' : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join(' ');
+          return html`
+            <div class="credit-item" data-tooltip="${label} Credits\nAvailable: ${c.creditAmount}">
+              <span class="credit-label">${label}</span>
+              <span class="credit-value">${c.creditAmount}</span>
+              <div class="credit-progress">
+                <div class="credit-fill" style="width: 100%; background: var(--vscode-charts-blue, #3794ff);"></div>
+              </div>
+            </div>
+          `;
+        }) : ''}
       </div>
     `;
   }

--- a/src/view/webview/types.ts
+++ b/src/view/webview/types.ts
@@ -100,6 +100,11 @@ export interface UserInfoData {
   upgradeText?: string;
 }
 
+export interface UserCreditData {
+  creditType: string;
+  creditAmount: string;
+}
+
 /** Token usage data */
 export interface TokenUsageData {
   promptCredits?: {
@@ -117,6 +122,7 @@ export interface TokenUsageData {
   totalAvailable: number;
   totalMonthly: number;
   overallRemainingPercentage: number;
+  userCredits?: UserCreditData[];
   formatted: {
     promptAvailable: string;
     promptMonthly: string;


### PR DESCRIPTION
This PR adds support for displaying user tier available credits (such as GOOGLE_ONE_AI) in both the VS Code status bar and the sidebar webview panel.